### PR TITLE
Fix raw string with quotes

### DIFF
--- a/tests/GrammarTest.php
+++ b/tests/GrammarTest.php
@@ -55,6 +55,7 @@ EOT
             ['r#"foo"#', 'foo'],
             ['r##"foo"##', 'foo'],
             ['r"\nfoo\r"', '\nfoo\r'],
+            ['r#"foo"bar"#', 'foo"bar'],
             ['r##"foo"#', self::ERROR],
         ];
     }


### PR DESCRIPTION
Raw strings that contain quotes currently fail to parse: `r#"foo"bar"#`

This is because of `anySingleBut('"')`, but we really need to capture input until a certain sequence. This seems tricky with Parsica.

This is my attempt at a fix, but it's causing another test to fail. Turns out, `takeWhile` succeeds if it encounters EOF, and I don't see a way to properly turn this into the expected failure.